### PR TITLE
v0.0.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/01_BUG_REPORT.md
@@ -1,6 +1,6 @@
 ---
 name: Bug Report
-about: Create a report to help Jax Linear Operator to improve
+about: Create a report to help JaxLinOp to improve
 title: "bug: "
 labels: "bug"
 assignees: ""
@@ -8,7 +8,7 @@ assignees: ""
 
 # Bug Report
 
-**Jax Linear Operator version:**
+**JaxLinOp version:**
 
 <!-- Please specify commit or tag version. -->
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+  # - repo: https://github.com/pycqa/isort
+  #   rev: 5.10.1
+  #   hooks:
+  #     - id: isort
+  #       args: ["--profile", "black"]
+  - repo: https://github.com/kynan/nbstripout
+    rev: 0.5.0
+    hooks:
+      - id: nbstripout
+  - repo: https://github.com/nbQA-dev/nbQA
+    rev: 1.3.1
+    hooks:
+      - id: nbqa-black
+      - id: nbqa-pyupgrade
+        args: [--py37-plus]
+      - id: nbqa-flake8
+        args: ['--ignore=E501,E203,E302,E402,E731,W503']

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+coverage:
+  range: 70..90
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%
+
+fixes:
+  - "/home/runner/work/gpjax/gpjax/::" # Correct paths
+
+ignore:
+  - "setup.py"
+  - "*/tests/.*"
+  - "__init__.py"
+  - "tests/*.py"

--- a/jaxlinop/__init__.py
+++ b/jaxlinop/__init__.py
@@ -1,4 +1,3 @@
-
 # Copyright 2022 The JaxLinOp Contributors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,16 +13,40 @@
 # limitations under the License.
 # ==============================================================================
 
-__version__ = "0.0.0"
+__version__ = "0.0.1"
 __authors__ = "Daniel Dodd, Thomas Pinder"
 __emails__ = "d.dodd1@lancaster.ac.uk, tompinder@live.co.uk"
 __license__ = "Apache 2.0"
-__uri__ = "https://github.com/JaxGaussianProcesses/JaxLinOp"
-__description__ = "A JAX linear operator library."
-__contributors__ = "https://github.com/JaxGaussianProcesses/JaxLinOp/graphs/contributors"
+__uri__ = "https://github.com/Daniel-Dodd/jax_linear_operator"
+__description__ = "A JaxLinOp library."
+__contributors__ = (
+    "https://github.com/Daniel-Dodd/jax_linear_operator/graphs/contributors"
+)
 
 from .linear_operator import LinearOperator
+from .dense_linear_operator import DenseLinearOperator
+from .diagonal_linear_operator import DiagonalLinearOperator
+from .constant_diagonal_linear_operator import ConstantDiagonalLinearOperator
+from .identity_linear_operator import IdentityLinearOperator
+from .zero_linear_operator import ZeroLinearOperator
+from .triangular_linear_operator import (
+    LowerTriangularLinearOperator,
+    UpperTriangularLinearOperator,
+)
+from .utils import (
+    identity,
+    to_dense,
+)
 
 __all__ = [
     "LinearOperator",
+    "DenseLinearOperator",
+    "DiagonalLinearOperator",
+    "ConstantDiagonalLinearOperator",
+    "IdentityLinearOperator",
+    "ZeroLinearOperator",
+    "LowerTriangularLinearOperator",
+    "UpperTriangularLinearOperator",
+    "identity",
+    "to_dense",
 ]

--- a/jaxlinop/constant_diagonal_linear_operator.py
+++ b/jaxlinop/constant_diagonal_linear_operator.py
@@ -1,0 +1,186 @@
+# Copyright 2022 The JaxLinOp Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from __future__ import annotations
+
+from typing import Tuple, Union, Any
+
+import jax.numpy as jnp
+from jaxtyping import Array, Float
+
+from .linear_operator import LinearOperator
+from .diagonal_linear_operator import DiagonalLinearOperator
+
+
+def _check_args(value: Any, size: Any) -> None:
+
+    if not isinstance(size, int):
+        raise ValueError(f"`length` must be an integer, but `length = {size}`.")
+
+    if value.ndim != 1:
+        raise ValueError(
+            f"`value` must be one dimensional scalar, but `value.shape = {value.shape}`."
+        )
+
+
+class ConstantDiagonalLinearOperator(DiagonalLinearOperator):
+    def __init__(self, value: Float[Array, "1"], size: int) -> None:
+        """Initialize the constant diagonal linear operator.
+
+        Args:
+            value (Float[Array, "1"]): Constant value of the diagonal.
+            size (int): Size of the diagonal.
+        """
+
+        _check_args(value, size)
+
+        self.value = value
+        self.size = size
+
+    def __add__(
+        self, other: Union[Float[Array, "N N"], LinearOperator]
+    ) -> DiagonalLinearOperator:
+        if isinstance(other, ConstantDiagonalLinearOperator):
+            if other.size == self.size:
+                return ConstantDiagonalLinearOperator(
+                    value=self.value + other.value, size=self.size
+                )
+
+            raise ValueError(
+                f"`length` must be the same, but `length = {self.size}` and `length = {other.size}`."
+            )
+
+        else:
+            return super().__add__(other)
+
+    def __mul__(self, other: float) -> LinearOperator:
+        """Multiply covariance operator by scalar.
+
+        Args:
+            other (LinearOperator): Scalar.
+
+        Returns:
+            LinearOperator: Covariance operator multiplied by a scalar.
+        """
+
+        return ConstantDiagonalLinearOperator(value=self.value * other, size=self.size)
+
+    def _add_diagonal(self, other: DiagonalLinearOperator) -> LinearOperator:
+        """Add diagonal to the covariance operator,  useful for computing, Kxx + Iσ².
+
+        Args:
+            other (DiagonalLinearOperator): Diagonal covariance operator to add to the covariance operator.
+
+        Returns:
+            LinearOperator: Covariance operator with the diagonal added.
+        """
+
+        if isinstance(other, ConstantDiagonalLinearOperator):
+            if other.size == self.size:
+                return ConstantDiagonalLinearOperator(
+                    value=self.value + other.value, size=self.size
+                )
+
+            raise ValueError(
+                f"`length` must be the same, but `length = {self.size}` and `length = {other.size}`."
+            )
+
+        else:
+            return super()._add_diagonal(other)
+
+    @property
+    def shape(self) -> Tuple[int, int]:
+        """Covaraince matrix shape.
+
+        Returns:
+            Tuple[int, int]: shape of the covariance operator.
+        """
+        return (self.size, self.size)
+
+    def diagonal(self) -> Float[Array, "N"]:
+        """Diagonal of the covariance operator."""
+        return self.value * jnp.ones(self.size)
+
+    def to_root(self) -> ConstantDiagonalLinearOperator:
+        """
+        Lower triangular.
+
+        Returns:
+            Float[Array, "N N"]: Lower triangular matrix.
+        """
+        return ConstantDiagonalLinearOperator(
+            value=jnp.sqrt(self.value), size=self.size
+        )
+
+    def log_det(self) -> Float[Array, "1"]:
+        """Log determinant.
+
+        Returns:
+            Float[Array, "1"]: Log determinant of the covariance matrix.
+        """
+        return 2.0 * self.size * jnp.log(self.value)
+
+    def inverse(self) -> ConstantDiagonalLinearOperator:
+        """Inverse of the covariance operator.
+
+        Returns:
+            DiagonalLinearOperator: Inverse of the covariance operator.
+        """
+        return ConstantDiagonalLinearOperator(value=1.0 / self.value, size=self.size)
+
+    def solve(self, rhs: Float[Array, "N M"]) -> Float[Array, "N M"]:
+        """Solve linear system.
+
+        Args:
+            rhs (Float[Array, "N M"]): Right hand side of the linear system.
+
+        Returns:
+            Float[Array, "N M"]: Solution of the linear system.
+        """
+
+        return rhs / self.value
+
+    @classmethod
+    def from_dense(cls, dense: Float[Array, "N N"]) -> ConstantDiagonalLinearOperator:
+        """Construct covariance operator from dense matrix.
+
+        Args:
+            dense (Float[Array, "N N"]): Dense matrix.
+
+        Returns:
+            DiagonalLinearOperator: Covariance operator.
+        """
+        return ConstantDiagonalLinearOperator(
+            value=jnp.atleast_1d(dense[0, 0]), size=dense.shape[0]
+        )
+
+    @classmethod
+    def from_root(
+        cls, root: ConstantDiagonalLinearOperator
+    ) -> ConstantDiagonalLinearOperator:
+        """Construct covariance operator from root.
+
+        Args:
+            root (ConstantDiagonalLinearOperator): Root of the covariance operator.
+
+        Returns:
+            ConstantDiagonalLinearOperator: Covariance operator.
+        """
+        return ConstantDiagonalLinearOperator(value=root.value**2, size=root.size)
+
+
+__all__ = [
+    "ConstantDiagonalLinearOperator",
+]

--- a/jaxlinop/dense_linear_operator.py
+++ b/jaxlinop/dense_linear_operator.py
@@ -1,0 +1,210 @@
+# Copyright 2022 The JaxLinOp Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .diagonal_linear_operator import DiagonalLinearOperator
+    from .triangular_linear_operator import LowerTriangularLinearOperator
+
+from typing import Tuple, Union
+
+import jax.numpy as jnp
+from jaxtyping import Array, Float
+
+from .linear_operator import LinearOperator
+from .utils import to_dense, to_linear_operator
+
+
+def _check_matrix(matrix: Array) -> None:
+    if matrix.ndim != 2:
+        raise ValueError(
+            f"The `matrix` must have at two dimensions, but "
+            f"`scale.shape = {matrix.shape}`."
+        )
+
+    if matrix.shape[-1] != matrix.shape[-2]:
+        raise ValueError(
+            f"The `matrix` must be a square matrix, but "
+            f"`scale.shape = {matrix.shape}`."
+        )
+
+
+class DenseLinearOperator(LinearOperator):
+    """Dense covariance operator."""
+
+    def __init__(self, matrix: Float[Array, "N N"]):
+        """Initialize the covariance operator.
+
+        Args:
+            matrix (Float[Array, "N N"]): Dense matrix.
+        """
+        _check_matrix(matrix)
+
+        self.matrix = matrix
+
+    def __add__(
+        self, other: Union[LinearOperator, Float[Array, "N N"]]
+    ) -> LinearOperator:
+        """Add diagonal to another linear operator.
+
+        Args:
+            other (Union[LinearOperator, Float[Array, "N N"]]): Other linear operator. Dimension of both operators must match. If the other linear operator is not a DiagonalLinearOperator, dense matrix addition is used.
+
+        Returns:
+            LinearOperator: linear operator plus the diagonal linear operator.
+        """
+
+        from .diagonal_linear_operator import DiagonalLinearOperator
+        from .zero_linear_operator import ZeroLinearOperator
+
+        other = to_linear_operator(other)
+
+        if isinstance(other, DiagonalLinearOperator):
+            return self._add_diagonal(other)
+
+        elif isinstance(other, DenseLinearOperator):
+            return DenseLinearOperator(matrix=self.matrix + other.matrix)
+
+        elif isinstance(other, ZeroLinearOperator):
+            return self
+
+        else:
+            raise NotImplementedError
+
+    def __mul__(self, other: float) -> LinearOperator:
+        """Multiply covariance operator by scalar.
+
+        Args:
+            other (LinearOperator): Scalar.
+
+        Returns:
+            LinearOperator: Covariance operator multiplied by a scalar.
+        """
+
+        return DenseLinearOperator(matrix=self.matrix * other)
+
+    def _add_diagonal(self, other: DiagonalLinearOperator) -> LinearOperator:
+        """Add diagonal to the covariance operator,  useful for computing, Kxx + Iσ².
+
+        Args:
+            other (DiagonalLinearOperator): Diagonal covariance operator to add to the covariance operator.
+
+        Returns:
+            LinearOperator: Sum of the two covariance operators.
+        """
+
+        n = self.shape[0]
+        diag_indices = jnp.diag_indices(n)
+        new_matrix = self.matrix.at[diag_indices].add(other.diagonal())
+
+        return DenseLinearOperator(matrix=new_matrix)
+
+    @property
+    def shape(self) -> Tuple[int, int]:
+        """Covaraince matrix shape.
+
+        Returns:
+            Tuple[int, int]: shape of the covariance operator.
+        """
+        return self.matrix.shape
+
+    def diagonal(self) -> Float[Array, "N"]:
+        """
+        Diagonal of the covariance operator.
+
+        Returns:
+            Float[Array, "N"]: The diagonal of the covariance operator.
+        """
+        return jnp.diag(self.matrix)
+
+    def __matmul__(self, other: Float[Array, "N M"]) -> Float[Array, "N M"]:
+        """Matrix multiplication.
+
+        Args:
+            other (Float[Array, "N M"]): Matrix to multiply with.
+
+        Returns:
+            Float[Array, "N M"]: Result of matrix multiplication.
+        """
+
+        return jnp.matmul(self.matrix, other)
+
+    def to_dense(self) -> Float[Array, "N N"]:
+        """Construct dense Covaraince matrix from the covariance operator.
+
+        Returns:
+            Float[Array, "N N"]: Dense covariance matrix.
+        """
+        return self.matrix
+
+    @classmethod
+    def from_dense(cls, matrix: Float[Array, "N N"]) -> DenseLinearOperator:
+        """Construct covariance operator from dense covariance matrix.
+
+        Args:
+            matrix (Float[Array, "N N"]): Dense covariance matrix.
+
+        Returns:
+            DenseLinearOperator: Covariance operator.
+        """
+
+        return DenseLinearOperator(matrix=matrix)
+
+    @classmethod
+    def from_root(cls, root: LowerTriangularLinearOperator) -> DenseLinearOperator:
+        """Construct covariance operator from the root of the covariance matrix.
+
+        Args:
+            root (Float[Array, "N N"]): Root of the covariance matrix.
+
+        Returns:
+            DenseLinearOperator: Covariance operator.
+        """
+
+        return _DenseFromRoot(root=root)
+
+
+class _DenseFromRoot(DenseLinearOperator):
+    def __init__(self, root: LinearOperator):
+        """Initialize the covariance operator."""
+
+        from .triangular_linear_operator import LowerTriangularLinearOperator
+
+        if not isinstance(root, LowerTriangularLinearOperator):
+            raise ValueError("root must be a LowerTriangularLinearOperator")
+
+        self.root = root
+
+    def to_root(self) -> LinearOperator:
+        return self.root
+
+    @property
+    def matrix(self) -> Float[Array, "N N"]:
+
+        dense_root = self.root.to_dense()
+
+        return dense_root @ dense_root.T
+
+    @property
+    def shape(self) -> Tuple[int, int]:
+        return self.root.shape
+
+
+__all__ = [
+    "DenseLinearOperator",
+]

--- a/jaxlinop/diagonal_linear_operator.py
+++ b/jaxlinop/diagonal_linear_operator.py
@@ -1,0 +1,225 @@
+# Copyright 2022 The JaxLinOp Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from __future__ import annotations
+
+from typing import Tuple, Union, Any
+
+import jax.numpy as jnp
+from jaxtyping import Array, Float
+
+from .linear_operator import LinearOperator
+from .dense_linear_operator import DenseLinearOperator
+from .utils import to_linear_operator
+
+
+def _check_diag(diag: Any) -> None:
+    """Check if the diagonal is a vector."""
+
+    if diag.ndim != 1:
+        raise ValueError(
+            f"The `matrix` must be a one dimension vector, but "
+            f"`diag.shape = {diag.shape}`."
+        )
+
+
+class DiagonalLinearOperator(LinearOperator):
+    """Diagonal covariance operator."""
+
+    def __init__(self, diag: Float[Array, "N"]) -> None:
+        """Initialize the covariance operator.
+
+        Args:
+            diag (Float[Array, "N"]): Diagonal of the covariance operator.
+        """
+        _check_diag(diag)
+        self.diag = diag
+
+    def diagonal(self) -> Float[Array, "N"]:
+        """Diagonal of the covariance operator.
+
+        Returns:
+            Float[Array, "N"]: Diagonal of the covariance operator.
+        """
+        return self.diag
+
+    def __add__(
+        self, other: Union[LinearOperator, Float[Array, "N N"]]
+    ) -> LinearOperator:
+        """Add diagonal to another linear operator.
+
+        Args:
+            other (Union[LinearOperator, Float[Array, "N N"]]): Other linear operator. Dimension of both operators must match. If the other linear operator is not a DiagonalLinearOperator, dense matrix addition is used.
+
+        Returns:
+            LinearOperator: linear operator plus the diagonal linear operator.
+        """
+
+        from .zero_linear_operator import ZeroLinearOperator
+
+        other = to_linear_operator(other)
+
+        if isinstance(other, DiagonalLinearOperator):
+            return DiagonalLinearOperator(diag=self.diagonal() + other.diagonal())
+
+        elif isinstance(other, DenseLinearOperator):
+            return other._add_diagonal(self)
+
+        elif isinstance(other, ZeroLinearOperator):
+            return self
+
+        else:
+            raise NotImplementedError
+
+    def __mul__(self, other: float) -> LinearOperator:
+        """Multiply covariance operator by scalar.
+
+        Args:
+            other (LinearOperator): Scalar.
+
+        Returns:
+            LinearOperator: Covariance operator multiplied by a scalar.
+        """
+
+        return DiagonalLinearOperator(diag=self.diagonal() * other)
+
+    def _add_diagonal(self, other: "DiagonalLinearOperator") -> LinearOperator:
+        """Add diagonal to the covariance operator,  useful for computing, Kxx + Iσ².
+
+        Args:
+            other (DiagonalLinearOperator): Diagonal covariance operator to add to the covariance operator.
+
+        Returns:
+            LinearOperator: Covariance operator with the diagonal added.
+        """
+
+        return DiagonalLinearOperator(diag=self.diagonal() + other.diagonal())
+
+    @property
+    def shape(self) -> Tuple[int, int]:
+        """Covaraince matrix shape.
+
+        Returns:
+            Tuple[int, int]: shape of the covariance operator.
+        """
+        N = self.diag.shape[0]
+        return (N, N)
+
+    def to_dense(self) -> Float[Array, "N N"]:
+        """Construct dense Covaraince matrix from the covariance operator.
+
+        Returns:
+            Float[Array, "N N"]: Dense covariance matrix.
+        """
+        return jnp.diag(self.diagonal())
+
+    def __matmul__(self, other: Float[Array, "N M"]) -> Float[Array, "N M"]:
+        """Matrix multiplication.
+
+        Args:
+            x (Float[Array, "N M"]): Matrix to multiply with.
+
+        Returns:
+            Float[Array, "N M"]: Result of matrix multiplication.
+        """
+        diag = (
+            self.diagonal() if other.ndim == 1 else jnp.expand_dims(self.diagonal(), -1)
+        )
+
+        return diag * other
+
+    def to_root(self) -> DiagonalLinearOperator:
+        """
+        Lower triangular.
+
+        Returns:
+            Float[Array, "N N"]: Lower triangular matrix.
+        """
+        return DiagonalLinearOperator(diag=jnp.sqrt(self.diagonal()))
+
+    def log_det(self) -> Float[Array, "1"]:
+        """Log determinant.
+
+        Returns:
+            Float[Array, "1"]: Log determinant of the covariance matrix.
+        """
+        return 2.0 * jnp.sum(jnp.log(self.diagonal()))
+
+    def inverse(self) -> DiagonalLinearOperator:
+        """Inverse of the covariance operator.
+
+        Returns:
+            DiagonalLinearOperator: Inverse of the covariance operator.
+        """
+        return DiagonalLinearOperator(diag=1.0 / self.diagonal())
+
+    def solve(self, rhs: Float[Array, "N M"]) -> Float[Array, "N M"]:
+        """Solve linear system.
+
+        Args:
+            rhs (Float[Array, "N M"]): Right hand side of the linear system.
+
+        Returns:
+            Float[Array, "N M"]: Solution of the linear system.
+        """
+
+        return self.inverse() @ rhs
+
+    @classmethod
+    def from_root(cls, root: DiagonalLinearOperator) -> DiagonalLinearOperator:
+        """Construct covariance operator from the lower triangular matrix.
+
+        Returns:
+            DiagonalLinearOperator: Covariance operator.
+        """
+        return _DiagonalFromRoot(root=root)
+
+    @classmethod
+    def from_dense(cls, dense: Float[Array, "N N"]) -> DiagonalLinearOperator:
+        """Construct covariance operator from its dense matrix representation.
+
+        Returns:
+            DiagonalLinearOperator: Covariance operator.
+        """
+        return DiagonalLinearOperator(diag=dense.diagonal())
+
+
+class _DiagonalFromRoot(DiagonalLinearOperator):
+    def __init__(self, root: DiagonalLinearOperator):
+        """Initialize the covariance operator."""
+
+        if not isinstance(root, DiagonalLinearOperator):
+            raise ValueError("root must be a DiagonalLinearOperator")
+
+        self.root = root
+
+    def to_root(self) -> LinearOperator:
+        return self.root
+
+    @property
+    def shape(self) -> Tuple[int, int]:
+        return self.root.shape
+
+    @property
+    def diag(self) -> Float[Array, "N"]:
+        return self.root.diagonal() ** 2
+
+    def diagonal(self) -> Float[Array, "N"]:
+        return self.root.diagonal() ** 2
+
+
+__all__ = [
+    "DiagonalLinearOperator",
+]

--- a/jaxlinop/identity_linear_operator.py
+++ b/jaxlinop/identity_linear_operator.py
@@ -1,0 +1,113 @@
+# Copyright 2022 The JaxLinOp Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from __future__ import annotations
+
+from typing import Tuple, Any, Union
+
+import jax.numpy as jnp
+from jaxtyping import Array, Float
+
+from .constant_diagonal_linear_operator import ConstantDiagonalLinearOperator
+from .utils import to_linear_operator
+
+
+def _check_size(size: Any) -> None:
+    """Check that size is an integer."""
+
+    if not isinstance(size, int):
+        raise ValueError(f"`size` must be an integer, but `size = {size}`.")
+
+
+class IdentityLinearOperator(ConstantDiagonalLinearOperator):
+    def __init__(self, size: int) -> None:
+        """Identity matrix.
+
+        Args:
+            size (int): Size of the identity matrix.
+        """
+        _check_size(size)
+        self.size = size
+        self.value = jnp.array([1.0])
+
+    def __matmul__(self, other: Float[Array, "N M"]) -> Float[Array, "N M"]:
+        """Matrix multiplication.
+
+        Args:
+            other (Float[Array, "N M"]): Matrix to multiply with.
+
+        Returns:
+            Float[Array, "N M"]: Result of matrix multiplication.
+        """
+        return other
+
+    def to_root(self) -> IdentityLinearOperator:
+        """
+        Lower triangular.
+
+        Returns:
+            Float[Array, "N N"]: Lower triangular matrix.
+        """
+        return self
+
+    def log_det(self) -> Float[Array, "1"]:
+        """Log determinant.
+
+        Returns:
+            Float[Array, "1"]: Log determinant of the covariance matrix.
+        """
+        return jnp.array(0.0)
+
+    def inverse(self) -> ConstantDiagonalLinearOperator:
+        """Inverse of the covariance operator.
+
+        Returns:
+            DiagonalLinearOperator: Inverse of the covariance operator.
+        """
+        return self
+
+    def solve(self, rhs: Float[Array, "N M"]) -> Float[Array, "N M"]:
+        """Solve linear system.
+
+        Args:
+            rhs (Float[Array, "N M"]): Right hand side of the linear system.
+
+        Returns:
+            Float[Array, "N M"]: Solution of the linear system.
+        """
+        # TODO: Check shapes.
+
+        return rhs
+
+    @classmethod
+    def from_root(cls, root: IdentityLinearOperator) -> IdentityLinearOperator:
+        """Construct from root.
+
+        Args:
+            root (IdentityLinearOperator): Root of the covariance operator.
+
+        Returns:
+            IdentityLinearOperator: Covariance operator.
+        """
+        return root
+
+    @classmethod
+    def from_dense(cls, dense: Float[Array, "N N"]) -> IdentityLinearOperator:
+        return IdentityLinearOperator(dense.shape[0])
+
+
+__all__ = [
+    "IdentityLinearOperator",
+]

--- a/jaxlinop/linear_operator.py
+++ b/jaxlinop/linear_operator.py
@@ -1,4 +1,4 @@
-# Copyright 2022 The Jax Linear Operator Contributors. All Rights Reserved.
+# Copyright 2022 The JaxLinOp Contributors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,18 +13,221 @@
 # limitations under the License.
 # ==============================================================================
 
+from __future__ import annotations
 
-class LinearOperator:
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .diagonal_linear_operator import DiagonalLinearOperator
+
+import abc
+import jax.numpy as jnp
+import distrax
+
+from jaxtyping import Array, Float
+from typing import Any, TypeVar, Iterable, Mapping, Generic, Tuple, Union
+
+from . import pytree
+
+# Generic type.
+T = TypeVar("T")
+
+# Generic nested type.
+NestedT = Union[T, Iterable["NestedT"], Mapping[Any, "NestedT"]]
+
+# Nested types.
+ShapeT = TypeVar("ShapeT", bound=NestedT[Tuple[int, ...]])
+DTypeT = TypeVar("DTypeT", bound=NestedT[jnp.dtype])
+
+
+class LinearOperator(pytree.Pytree, Generic[ShapeT, DTypeT], metaclass=abc.ABCMeta):
     """Linear operator base class."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        """Initialise linear operator."""
+        self._args = args
+        self._kwargs = kwargs
 
     @property
     def name(self) -> str:
-        """Name of the linear operator.
+        """Linear operator name."""
+        return type(self).__name__
+
+    @property
+    @abc.abstractmethod
+    def shape(self) -> ShapeT:
+        """Linear operator shape."""
+        raise NotImplementedError
+
+    @property
+    def dtype(self) -> DTypeT:
+        """Linear operator data type."""
+        return self._args[0].dtype
+
+    @property
+    def ndim(self) -> int:
+        """Linear operator dimension."""
+        return len(self.shape)
+
+    @property
+    def T(self) -> LinearOperator:
+        """Transpose linear operator. Currently, we assume all linear operators are square and symmetric."""
+        return self
+
+    def __sub__(
+        self, other: Union[LinearOperator, Float[Array, "N N"]]
+    ) -> LinearOperator:
+        """Subtract linear operator."""
+        return self + (other * -1)
+
+    def __rsub__(
+        self, other: Union[LinearOperator, Float[Array, "N N"]]
+    ) -> LinearOperator:
+        """Reimplimentation of subtract linear operator."""
+        return (self * -1) + other
+
+    def __add__(
+        self, other: Union[LinearOperator, Float[Array, "N N"]]
+    ) -> LinearOperator:
+        """Add linear operator."""
+        raise NotImplementedError
+
+    def __radd__(
+        self, other: Union[LinearOperator, Float[Array, "N N"]]
+    ) -> LinearOperator:
+        """Reimplimentation of add linear operator."""
+        return self + other
+
+    @abc.abstractmethod
+    def __mul__(self, other: float) -> LinearOperator:
+        """Multiply linear operator by scalar."""
+        raise NotImplementedError
+
+    def __rmul__(self, other: float) -> LinearOperator:
+        """Reimplimentation of multiply linear operator by scalar."""
+        return self.__mul__(other)
+
+    @abc.abstractmethod
+    def _add_diagonal(self, other: DiagonalLinearOperator) -> LinearOperator:
+        """Add diagonal linear operator to a linear operator, useful e.g., for adding jitter."""
+        return NotImplementedError
+
+    @abc.abstractmethod
+    def __matmul__(
+        self, other: Union[LinearOperator, Float[Array, "N M"]]
+    ) -> Union[LinearOperator, Float[Array, "N M"]]:
+        """Matrix multiplication."""
+        raise NotImplementedError
+
+    def __rmatmul__(
+        self, other: Union[LinearOperator, Float[Array, "N M"]]
+    ) -> Union[LinearOperator, Float[Array, "N M"]]:
+        """Reimplimentation of matrix multiplication."""
+        # Exploit the fact that linear operators are square and symmetric.
+        if other.ndim == 1:
+            return self.T @ other
+        return (self.T @ other.T).T
+
+    @abc.abstractmethod
+    def diagonal(self) -> Float[Array, "N"]:
+        """Diagonal of the linear operator.
 
         Returns:
-            str: Name of the linear operator.
+            Float[Array, "N"]: Diagonal of the linear operator.
         """
-        return self.__class__.__name__
+
+        raise NotImplementedError
+
+    def trace(self) -> Float[Array, "1"]:
+        """Trace of the linear matrix.
+
+        Returns:
+            Float[Array, "1"]: Trace of the linear matrix.
+        """
+        return jnp.sum(self.diagonal())
+
+    def log_det(self) -> Float[Array, "1"]:
+        """Log determinant of the linear matrix. Default implementation uses dense Cholesky decomposition.
+
+        Returns:
+            Float[Array, "1"]: Log determinant of the linear matrix.
+        """
+
+        root = self.to_root()
+
+        return 2.0 * jnp.sum(jnp.log(root.diagonal()))
+
+    def to_root(self) -> LinearOperator:
+        """Compute the root of the linear operator via the Cholesky decomposition.
+
+        Returns:
+            Float[Array, "N N"]: Lower Cholesky decomposition of the linear operator.
+        """
+
+        from .triangular_linear_operator import LowerTriangularLinearOperator
+
+        L = jnp.linalg.cholesky(self.to_dense())
+
+        return LowerTriangularLinearOperator.from_dense(L)
+
+    def inverse(self) -> LinearOperator:
+        """Inverse of the linear matrix. Default implementation uses dense Cholesky decomposition.
+
+        Returns:
+            LinearOperator: Inverse of the linear matrix.
+        """
+
+        from .dense_linear_operator import DenseLinearOperator
+
+        n = self.shape[0]
+
+        return DenseLinearOperator(self.solve(jnp.eye(n)))
+
+    def solve(self, rhs: Float[Array, "N M"]) -> Float[Array, "N M"]:
+        """Solve linear system. Default implementation uses dense Cholesky decomposition.
+
+        Args:
+            rhs (Float[Array, "N M"]): Right hand side of the linear system.
+
+        Returns:
+            Float[Array, "N M"]: Solution of the linear system.
+        """
+
+        root = self.to_root()
+        rootT = root.T
+
+        return rootT.solve(root.solve(rhs))
+
+    @abc.abstractmethod
+    def to_dense(self) -> Float[Array, "N N"]:
+        """Construct dense Covaraince matrix from the linear operator.
+
+        Returns:
+            Float[Array, "N N"]: Dense linear matrix.
+        """
+        raise NotImplementedError
+
+    @classmethod
+    @abc.abstractmethod
+    def from_dense(cls, dense: Float[Array, "N N"]) -> LinearOperator:
+        """Construct linear operator from dense matrix.
+
+        Args:
+            dense (Float[Array, "N N"]): Dense matrix.
+
+        Returns:
+            LinearOperator: Linear operator.
+        """
+        raise NotImplementedError
+
+    @classmethod
+    def to_bijector(cls) -> distrax.Bijector:
+        """Construct bijector from linear operator.
+
+        Returns:
+            Bijector: Bijector.
+        """
+        raise NotImplementedError
 
 
 __all__ = [

--- a/jaxlinop/linear_operator.py
+++ b/jaxlinop/linear_operator.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from functools import cache
 
 if TYPE_CHECKING:
     from .diagonal_linear_operator import DiagonalLinearOperator

--- a/jaxlinop/pytree.py
+++ b/jaxlinop/pytree.py
@@ -1,0 +1,76 @@
+# Copyright 2022 The JaxLinOp Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import abc
+import jax
+
+from typing import Any
+
+
+class Pytree(metaclass=abc.ABCMeta):
+    """An abstract base class for a JAX compatible pytree. Adapted from `distrax._src.utils.jittable.Jittable`."""
+
+    def __new__(cls, *args, **kwargs):
+        # Discard the parameters to this function because the constructor is not
+        # called during serialization: its `__dict__` gets repopulated directly.
+        del args, kwargs
+        try:
+            registered_cls = jax.tree_util.register_pytree_node_class(cls)
+        except ValueError:
+            registered_cls = cls  # Already registered.
+        return object.__new__(registered_cls)
+
+    def tree_flatten(self):
+        leaves, treedef = jax.tree_util.tree_flatten(self.__dict__)
+        switch = list(map(is_jax_type, leaves))
+        children = [leaf if s else None for leaf, s in zip(leaves, switch)]
+        metadata = [None if s else leaf for leaf, s in zip(leaves, switch)]
+        return children, (metadata, switch, treedef)
+
+    @classmethod
+    def tree_unflatten(cls, aux_data, children):
+        metadata, switch, treedef = aux_data
+        leaves = [j if s else p for j, p, s in zip(children, metadata, switch)]
+        obj = object.__new__(cls)
+        obj.__dict__ = jax.tree_util.tree_unflatten(treedef, leaves)
+        return obj
+
+
+def is_jax_type(x: Any) -> bool:
+    """Check whether `x` is an instance of a JAX-compatible type."""
+    # If it's a tracer, then it's already been converted by JAX.
+    if isinstance(x, jax.core.Tracer):
+        return True
+
+    # `jax.vmap` replaces vmappable leaves with `object()` during serialization.
+    if type(x) is object:  # pylint: disable=unidiomatic-typecheck
+        return True
+
+    # Primitive types (e.g. shape tuples) are treated as metadata for Distrax.
+    if isinstance(x, (bool, int, float)) or x is None:
+        return False
+
+    # Otherwise, try to make it into a tracer. If it succeeds, then it's JAX data.
+    try:
+        jax.xla.abstractify(x)
+        return True
+    except TypeError:
+        return False
+
+
+__all__ = [
+    "Pytree",
+    "is_jax_type",
+]

--- a/jaxlinop/triangular_linear_operator.py
+++ b/jaxlinop/triangular_linear_operator.py
@@ -1,0 +1,92 @@
+# Copyright 2022 The JaxLinOp Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.scipy as jsp
+from jaxtyping import Array, Float
+
+from .linear_operator import LinearOperator
+from .dense_linear_operator import DenseLinearOperator
+
+
+class LowerTriangularLinearOperator(DenseLinearOperator):
+    """Current implementation of the following methods is inefficient.
+    We assume a dense matrix representation of the operator. But take advantage of the solve structure."""
+
+    @property
+    def T(self) -> UpperTriangularLinearOperator:
+        return UpperTriangularLinearOperator(matrix=self.matrix.T)
+
+    def to_root(self) -> LinearOperator:
+        raise ValueError("Matrix is not positive semi-definite.")
+
+    def inverse(self) -> DenseLinearOperator:
+        matrix = self.solve(jnp.eye(self.size))
+        return DenseLinearOperator(matrix)
+
+    def solve(self, rhs: Float[Array, "N"]) -> Float[Array, "N"]:
+        return jsp.linalg.solve_triangular(self.to_dense(), rhs, lower=True)
+
+    def __matmul__(self, other):
+        return super().__matmul__(other)
+
+    def __add__(self, other):
+        return super().__matmul__(other)
+
+    @classmethod
+    def from_root(cls, root: LinearOperator) -> None:
+        raise ValueError("LowerTriangularLinearOperator does not have a root.")
+
+    @classmethod
+    def from_dense(cls, dense: Float[Array, "N N"]) -> LowerTriangularLinearOperator:
+        return LowerTriangularLinearOperator(matrix=dense)
+
+
+class UpperTriangularLinearOperator(DenseLinearOperator):
+    """Current implementation of the following methods is inefficient.
+    We assume a dense matrix representation of the operator. But take advantage of the solve structure."""
+
+    @property
+    def T(self) -> LowerTriangularLinearOperator:
+        return LowerTriangularLinearOperator(matrix=self.matrix.T)
+
+    def to_root(self) -> LinearOperator:
+        raise ValueError("Matrix is not positive semi-definite.")
+
+    def inverse(self) -> DenseLinearOperator:
+        matrix = self.solve(jnp.eye(self.size))
+        return DenseLinearOperator(matrix)
+
+    def __matmul__(self, other):
+        return super().__matmul__(other)
+
+    def __add__(self, other):
+        return super().__matmul__(other)
+
+    def solve(self, rhs: Float[Array, "N"]) -> Float[Array, "N"]:
+        return jsp.linalg.solve_triangular(self.to_dense(), rhs, lower=True)
+
+    @classmethod
+    def from_root(cls, root: LinearOperator) -> None:
+        raise ValueError("LowerTriangularLinearOperator does not have a root.")
+
+    @classmethod
+    def from_dense(cls, dense: Float[Array, "N N"]) -> UpperTriangularLinearOperator:
+        return UpperTriangularLinearOperator(matrix=dense)
+
+
+__all__ = ["TriangularLinearOperator"]

--- a/jaxlinop/triangular_linear_operator.py
+++ b/jaxlinop/triangular_linear_operator.py
@@ -78,7 +78,7 @@ class UpperTriangularLinearOperator(DenseLinearOperator):
         return super().__matmul__(other)
 
     def solve(self, rhs: Float[Array, "N"]) -> Float[Array, "N"]:
-        return jsp.linalg.solve_triangular(self.to_dense(), rhs, lower=True)
+        return jsp.linalg.solve_triangular(self.to_dense(), rhs, lower=False)
 
     @classmethod
     def from_root(cls, root: LinearOperator) -> None:

--- a/jaxlinop/utils.py
+++ b/jaxlinop/utils.py
@@ -1,0 +1,111 @@
+# Copyright 2022 The JaxLinOp Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from __future__ import annotations
+
+from typing import Union, Tuple, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .identity_linear_operator import IdentityLinearOperator
+
+from jaxtyping import Float, Array
+
+import jax.numpy as jnp
+
+from .linear_operator import LinearOperator
+
+
+def identity(n: int) -> IdentityLinearOperator:
+    """Identity matrix.
+
+    Args:
+        n (int): Size of the identity matrix.
+
+    Returns:
+        IdentityLinearOperator: Identity matrix of shape [n, n].
+    """
+
+    from .identity_linear_operator import IdentityLinearOperator
+
+    return IdentityLinearOperator(size=n)
+
+
+def to_dense(obj: Union[Float[Array, "..."], LinearOperator]):
+    """
+    Ensure an object is a dense matrix.
+
+    Args:
+        obj (Union[Float[Array, "..."], LinearOperator]): Linear operator to convert.
+
+    Returns:
+        Float[Array, "..."]: Dense matrix.
+    """
+    if isinstance(obj, jnp.ndarray):
+        return obj
+    elif isinstance(obj, LinearOperator):
+        return obj.to_dense()
+    else:
+        raise TypeError(
+            "object of class {} cannot be made into a Tensor".format(
+                obj.__class__.__name__
+            )
+        )
+
+
+def to_linear_operator(obj: Union[Float[Array, "..."], LinearOperator]):
+    """
+    Ensure an object is a linear operator.
+
+    Args:
+        obj (Union[Float[Array, "..."], LinearOperator]): Linear operator to convert.
+
+    Returns:
+        LinearOperator: Linear operator.
+    """
+    if isinstance(obj, LinearOperator):
+        return obj
+
+    elif isinstance(obj, jnp.ndarray):
+        from .dense_linear_operator import DenseLinearOperator
+
+        return DenseLinearOperator.from_dense(obj)
+    else:
+        raise TypeError(
+            "object of class {} cannot be made into a Tensor".format(
+                obj.__class__.__name__
+            )
+        )
+
+
+def check_shapes_match(shape1: Tuple[int, ...], shape2: Tuple[int, ...]) -> None:
+    """Check shapes of two objects.
+
+    Args:
+        shape1 (Tuple[int, ...]): Shape of the first object.
+        shape2 (Tuple[int, ...]): Shape of the second object.
+
+    Raises:
+        ValueError: Shapes of the two objects do not match.
+    """
+    if shape1 != shape2:
+        raise ValueError(
+            f"`shape1` must have shape {shape1}, but `shape2` has shape {shape2}."
+        )
+
+
+__all__ = [
+    "identity",
+    "to_dense",
+]

--- a/jaxlinop/zero_linear_operator.py
+++ b/jaxlinop/zero_linear_operator.py
@@ -1,0 +1,183 @@
+# Copyright 2022 The JaxLinOp Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from __future__ import annotations
+
+from typing import Any, Tuple, Union
+
+import jax.numpy as jnp
+from jaxtyping import Array, Float
+
+from .linear_operator import LinearOperator
+from .diagonal_linear_operator import DiagonalLinearOperator
+from .utils import check_shapes_match, to_linear_operator
+
+
+def _check_size(size: Any) -> None:
+
+    if not isinstance(size, int):
+        raise ValueError(f"`length` must be an integer, but `length = {size}`.")
+
+
+class ZeroLinearOperator(LinearOperator):
+
+    # TODO: Generalise to non-square matrices.
+
+    def __init__(self, size: int) -> None:
+
+        _check_size(size)
+        self.size = size
+
+    @property
+    def shape(self) -> Tuple[int, int]:
+        """Covaraince matrix shape.
+
+        Returns:
+            Tuple[int, int]: shape of the covariance operator.
+        """
+        return (self.size, self.size)
+
+    def diagonal(self) -> Float[Array, "N"]:
+        """
+        Diagonal of the covariance operator.
+
+        Returns:
+            Float[Array, "N"]: The diagonal of the covariance operator.
+        """
+        return jnp.zeros(self.size)
+
+    def __add__(
+        self, other: Union[Float[Array, "N N"], LinearOperator]
+    ) -> Union[Float[Array, "N N"], LinearOperator]:
+        """Add covariance operator to another covariance operator.
+
+        Args:
+            other (Union[Float[Array, "N N"], LinearOperator]): Covariance operator to add.
+
+        Returns:
+            Union[Float[Array, "N N"], LinearOperator]: Sum of the covariance operators.
+        """
+        check_shapes_match(self.shape, other.shape)
+        return to_linear_operator(other)
+
+    def _add_diagonal(self, other: DiagonalLinearOperator) -> DiagonalLinearOperator:
+        """Add diagonal to the covariance operator,  useful for computing, Kxx + Iσ².
+
+        Args:
+            other (DiagonalLinearOperator): Diagonal covariance operator to add to the covariance operator.
+
+        Returns:
+            DiagonalLinearOperator: Covariance operator with the diagonal added.
+        """
+        check_shapes_match(self.shape, other.shape)
+        return other
+
+    def __mul__(self, other: float) -> ZeroLinearOperator:
+        """Multiply covariance operator by scalar.
+
+        Args:
+            other (ConstantDiagonalLinearOperator): Scalar.
+
+        Returns:
+            ZeroLinearOperator: Covariance operator multiplied by a scalar.
+        """
+        # TODO: check shapes.
+        return self
+
+    def __matmul__(
+        self, other: Union[LinearOperator, Float[Array, "N M"]]
+    ) -> ZeroLinearOperator:
+        """Matrix multiplication.
+
+        Args:
+            other (Union[LinearOperator, Float[Array, "N M"]]): Matrix to multiply with.
+
+        Returns:
+            Float[Array, "N M"]: Result of matrix multiplication.
+        """
+        check_shapes_match(self.shape, other.shape)
+        return self
+
+    def to_dense(self) -> Float[Array, "N N"]:
+        """Construct dense Covaraince matrix from the covariance operator.
+
+        Returns:
+            Float[Array, "N N"]: Dense covariance matrix.
+        """
+        return jnp.zeros(self.shape)
+
+    def to_root(self) -> ZeroLinearOperator:
+        """
+        Root of the covariance operator.
+
+        Returns:
+            ZeroLinearOperator: Root of the covariance operator.
+        """
+        return self
+
+    def log_det(self) -> Float[Array, "1"]:
+        """Log determinant.
+
+        Returns:
+            Float[Array, "1"]: Log determinant of the covariance matrix.
+        """
+        return jnp.log(jnp.array(0.0))
+
+    def inverse(self) -> None:
+        """Inverse of the covariance operator.
+
+        Raises:
+            RuntimeError: ZeroLinearOperator is not invertible.
+        """
+        raise RuntimeError("ZeroLinearOperator is not invertible.")
+
+    def solve(self, rhs: Float[Array, "N M"]) -> None:
+        """Solve linear system.
+
+        Raises:
+            RuntimeError: ZeroLinearOperator is not invertible.
+        """
+        raise RuntimeError("ZeroLinearOperator is not invertible.")
+
+    @classmethod
+    def from_root(cls, root: ZeroLinearOperator) -> ZeroLinearOperator:
+        """Construct covariance operator from the root.
+
+        Args:
+            root (ZeroLinearOperator): Root of the covariance operator.
+
+        Returns:
+            ZeroLinearOperator: Covariance operator.
+        """
+        return root
+
+    @classmethod
+    def from_dense(cls, dense: Float[Array, "N N"]) -> ZeroLinearOperator:
+        """Construct covariance operator from the dense matrix.
+
+        Args:
+            dense (Float[Array, "N N"]): Dense matrix.
+
+        Returns:
+            ZeroLinearOperator: Covariance operator.
+        """
+
+        # TODO: check shapes.
+        return ZeroLinearOperator(dense.shape[0])
+
+
+__all__ = [
+    "ZeroLinearOperator",
+]

--- a/setup.py
+++ b/setup.py
@@ -16,20 +16,22 @@ CLASSIFIERS = [
 ]
 
 INSTALL_REQUIRES = [
-    "jax", 
-    "jaxlib", 
-    "jaxtyping"
+    "jax",
+    "jaxlib",
+    "jaxtyping",
+    "distrax",
 ]
 
 EXTRA_REQUIRE = {
     "dev": [
-        "pytest", 
+        "pytest",
         "pre-commit",
         "pytest-cov",
     ],
 }
 
 GLOBAL_PATH = os.path.dirname(os.path.realpath(__file__))
+
 
 def read(*local_path: str) -> str:
     """Read a file, given a local path.
@@ -43,9 +45,11 @@ def read(*local_path: str) -> str:
     with codecs.open(os.path.join(GLOBAL_PATH, *local_path), "rb", "utf-8") as f:
         return f.read()
 
+
 # Read `__init__` file:
 init_local_path = os.path.join(NAME, "__init__.py")
 init_file = read(init_local_path)
+
 
 def find_meta(meta: str) -> str:
     """Extract `__*meta*__` from the `__init__.py` file. This is useful for extracting __version__, __author__, etc.
@@ -58,13 +62,12 @@ def find_meta(meta: str) -> str:
     """
 
     matches = re.search(
-        r"^__{meta}__ = ['\"]([^'\"]*)['\"]".format(meta=meta), 
-        init_file, 
-        re.M
+        r"^__{meta}__ = ['\"]([^'\"]*)['\"]".format(meta=meta), init_file, re.M
     )
     if matches:
         return matches.group(1)
     raise RuntimeError("Unable to find __{meta}__ string.".format(meta=meta))
+
 
 if __name__ == "__main__":
     setup(

--- a/tests/test_constant_linear_operator.py
+++ b/tests/test_constant_linear_operator.py
@@ -1,0 +1,245 @@
+# Copyright 2022 The JaxLinOp Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+from jax.config import config
+
+
+# Enable Float64 for more stable matrix inversions.
+config.update("jax_enable_x64", True)
+_PRNGKey = jr.PRNGKey(42)
+
+from jaxlinop.diagonal_linear_operator import DiagonalLinearOperator
+from jaxlinop.dense_linear_operator import DenseLinearOperator
+from jaxlinop.constant_diagonal_linear_operator import ConstantDiagonalLinearOperator
+
+
+def approx_equal(res: jnp.ndarray, actual: jnp.ndarray) -> bool:
+    """Check if two arrays are approximately equal."""
+    return jnp.linalg.norm(res - actual) < 1e-6
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_init(n: int) -> None:
+    value = jr.uniform(_PRNGKey, (1,))
+    constant_diag = ConstantDiagonalLinearOperator(value=value, size=n)
+    assert constant_diag.shape == (n, n)
+    assert constant_diag.size == n
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_diag(n: int) -> None:
+    value = jr.uniform(_PRNGKey, (1,))
+    constant_diag = ConstantDiagonalLinearOperator(value=value, size=n)
+    res = constant_diag.diagonal()
+    actual = jnp.ones(n) * value
+    assert approx_equal(res, actual)
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_to_dense(n: int) -> None:
+    value = jr.uniform(_PRNGKey, (1,))
+    constant_diag = ConstantDiagonalLinearOperator(value=value, size=n)
+    actual = jnp.diag(jnp.ones(n) * value)
+    res = constant_diag.to_dense()
+    assert approx_equal(res, actual)
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_add_diagonal(n: int) -> None:
+
+    # Test adding two constant diagonal linear operators.
+    key_a, key_b = jr.split(_PRNGKey)
+
+    value_a = jr.uniform(key_a, (1,))
+    constant_diag_a = ConstantDiagonalLinearOperator(value=value_a, size=n)
+
+    value_b = jr.uniform(key_b, (1,))
+    constant_diag_b = ConstantDiagonalLinearOperator(value=value_b, size=n)
+
+    res = constant_diag_a._add_diagonal(constant_diag_b)
+    actual = jnp.diag(jnp.ones(n) * (value_a + value_b))
+
+    assert isinstance(res, ConstantDiagonalLinearOperator)
+    assert res.shape == (n, n)
+    assert res.size == n
+    assert approx_equal(res.to_dense(), actual)
+
+    # Test adding on the generic diagonal linear operator.
+    key = _PRNGKey
+
+    value = jr.uniform(key, (1,))
+    constant_diag = ConstantDiagonalLinearOperator(value=value, size=n)
+    actual = jnp.diag(jnp.ones(n) * value)
+
+    random_diag = DiagonalLinearOperator(jr.uniform(key, (n,)))
+
+    res = constant_diag._add_diagonal(random_diag)
+    actual = jnp.diag(jnp.ones(n) * value + random_diag.diagonal())
+
+    assert isinstance(res, DiagonalLinearOperator)
+    assert res.shape == (n, n)
+
+    assert approx_equal(res.to_dense(), actual)
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_add(n: int) -> None:
+    key = _PRNGKey
+
+    array = jr.uniform(_PRNGKey, shape=(n, n))
+    entries = jr.uniform(_PRNGKey, shape=(n,))
+    value = jr.uniform(key, (1,))
+    constant_diag = ConstantDiagonalLinearOperator(value=value, size=n)
+
+    # Add array.
+    res_left = constant_diag + array
+    res_right = array + constant_diag
+
+    assert approx_equal(res_left.to_dense(), array + value * jnp.eye(n))
+    assert approx_equal(res_right.to_dense(), array + value * jnp.eye(n))
+
+    # Add Dense.
+    array = jr.uniform(_PRNGKey, shape=(n, n))
+    dense = DenseLinearOperator(matrix=array)
+
+    res_left = constant_diag + dense
+    res_right = dense + constant_diag
+    actual = dense.to_dense() + value * jnp.eye(n)
+
+    assert isinstance(res_left, DenseLinearOperator)
+    assert isinstance(res_right, DenseLinearOperator)
+    assert approx_equal(res_left.to_dense(), actual)
+    assert approx_equal(res_right.to_dense(), actual)
+
+    # Add Diagonal.
+    diag = DiagonalLinearOperator(diag=entries)
+
+    res_left = constant_diag + diag
+    res_right = diag + constant_diag
+    actual = diag.to_dense() + value * jnp.eye(n)
+
+    assert isinstance(res_left, DiagonalLinearOperator)
+    assert isinstance(res_right, DiagonalLinearOperator)
+    assert approx_equal(res_left.to_dense(), actual)
+    assert approx_equal(res_right.to_dense(), actual)
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_mul(n: int) -> None:
+    key, subkey = jr.split(_PRNGKey, 2)
+    constant = jr.uniform(key, shape=())
+    value = jr.uniform(subkey, shape=(1,))
+    constant_diag = ConstantDiagonalLinearOperator(value=value, size=n)
+
+    res_left = constant_diag * constant
+    res_right = constant * constant_diag
+
+    assert isinstance(res_left, ConstantDiagonalLinearOperator)
+    assert isinstance(res_right, ConstantDiagonalLinearOperator)
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_matmul(n: int) -> None:
+    array = jr.uniform(_PRNGKey, shape=(n, n))
+    value = jr.uniform(_PRNGKey, shape=(1,))
+    constant_diag = ConstantDiagonalLinearOperator(value=value, size=n)
+
+    res_left = constant_diag @ array
+    res_right = array @ constant_diag
+
+    assert approx_equal(res_left, constant_diag.to_dense() @ array)
+    assert approx_equal(res_right, array @ constant_diag.to_dense())
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_solve(n: int) -> None:
+    value = jr.uniform(_PRNGKey, shape=(1,))
+    constant_diag = ConstantDiagonalLinearOperator(value=value, size=n)
+    rhs = jr.uniform(_PRNGKey, shape=(n,))
+    constant_diag.solve(rhs)
+
+    assert approx_equal(constant_diag.solve(rhs), rhs / value)
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_inverse(n: int) -> None:
+    value = jr.uniform(_PRNGKey, shape=(1,))
+    constant_diag = ConstantDiagonalLinearOperator(value=value, size=n)
+
+    res = constant_diag.inverse()
+
+    assert isinstance(res, ConstantDiagonalLinearOperator)
+    assert approx_equal(res.to_dense(), jnp.diag(1 / constant_diag.diagonal()))
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_to_root(n: int) -> None:
+    value = jr.uniform(_PRNGKey, shape=(1,))
+    constant_diag = ConstantDiagonalLinearOperator(value=value, size=n)
+
+    res = constant_diag.to_root()
+    actual = ConstantDiagonalLinearOperator(value=jnp.sqrt(value), size=n)
+
+    assert isinstance(res, ConstantDiagonalLinearOperator)
+    assert approx_equal(res.to_dense(), actual.to_dense())
+    assert res.shape == actual.shape
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_log_det(n: int) -> None:
+    value = jr.uniform(_PRNGKey, shape=(1,))
+    constant_diag = ConstantDiagonalLinearOperator(value=value, size=n)
+    res = constant_diag.log_det()
+    actual = jnp.log(value) * n
+
+    approx_equal(res, actual)
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_trace(n: int) -> None:
+    value = jr.uniform(_PRNGKey, shape=(1,))
+    constant_diag = ConstantDiagonalLinearOperator(value=value, size=n)
+    res = constant_diag.trace()
+    actual = value * n
+
+    assert res == actual
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_from_root(n: int) -> None:
+    value = jr.uniform(_PRNGKey, shape=(1,))
+    root = ConstantDiagonalLinearOperator(value=value, size=n)
+    constant_diag = ConstantDiagonalLinearOperator.from_root(root)
+    res = constant_diag.to_dense()
+    actual = jnp.diag(root.diagonal() ** 2)
+
+    assert isinstance(constant_diag, ConstantDiagonalLinearOperator)
+    assert approx_equal(res, actual)
+    assert res.shape == actual.shape
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_from_dense(n: int) -> None:
+    dense = jr.uniform(_PRNGKey, shape=(n, n))
+    res = ConstantDiagonalLinearOperator.from_dense(dense)
+    actual = jnp.diag(jnp.ones(n) * dense[0, 0])
+
+    assert isinstance(res, ConstantDiagonalLinearOperator)
+    assert approx_equal(res.to_dense(), actual)
+    assert res.shape == actual.shape

--- a/tests/test_dense_linear_operator.py
+++ b/tests/test_dense_linear_operator.py
@@ -1,0 +1,233 @@
+# Copyright 2022 The JaxLinOp Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+from jax.config import config
+
+
+# Enable Float64 for more stable matrix inversions.
+config.update("jax_enable_x64", True)
+_PRNGKey = jr.PRNGKey(42)
+
+from jaxlinop.diagonal_linear_operator import DiagonalLinearOperator
+from jaxlinop.dense_linear_operator import DenseLinearOperator
+from jaxlinop.triangular_linear_operator import LowerTriangularLinearOperator
+
+
+def approx_equal(res: jnp.ndarray, actual: jnp.ndarray) -> bool:
+    """Check if two arrays are approximately equal."""
+    return jnp.linalg.norm(res - actual) < 1e-6
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_init(n: int) -> None:
+    values = jr.uniform(_PRNGKey, (n, n))
+    dense = DenseLinearOperator(values)
+    assert dense.shape == (n, n)
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_diag(n: int) -> None:
+    values = jr.uniform(_PRNGKey, (n, n))
+    dense = DenseLinearOperator(values)
+    res = dense.diagonal()
+    actual = values.diagonal()
+    assert approx_equal(res, actual)
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_to_dense(n: int) -> None:
+    values = jr.uniform(_PRNGKey, (n, n))
+    dense = DenseLinearOperator(values)
+    actual = values
+    res = dense.to_dense()
+    assert approx_equal(res, actual)
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_add_diagonal(n: int) -> None:
+
+    # Test adding generic diagonal linear operator.
+    key_a, key_b = jr.split(_PRNGKey)
+
+    values_a = jr.uniform(key_a, (n, n))
+    dense = DenseLinearOperator(values_a)
+
+    values_b = jr.uniform(key_b, (n,))
+    diag = DiagonalLinearOperator(values_b)
+
+    res = dense._add_diagonal(diag)
+    actual = values_a + jnp.diag(values_b)
+
+    assert isinstance(res, DenseLinearOperator)
+    assert res.shape == (n, n)
+    assert approx_equal(res.to_dense(), actual)
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_add(n: int) -> None:
+    key = _PRNGKey
+
+    array = jr.uniform(_PRNGKey, shape=(n, n))
+    entries = jr.uniform(_PRNGKey, shape=(n,))
+    values = jr.uniform(key, (n, n))
+    dense = DenseLinearOperator(values)
+
+    # Add array.
+    res_left = dense + array
+    res_right = array + dense
+
+    assert approx_equal(res_left.to_dense(), array + values)
+    assert approx_equal(res_right.to_dense(), array + values)
+    assert isinstance(res_left, DenseLinearOperator)
+    assert isinstance(res_right, DenseLinearOperator)
+
+    # Add Dense.
+    array = jr.uniform(_PRNGKey, shape=(n, n))
+    dense = DenseLinearOperator(matrix=array)
+
+    res_left = array + dense
+    res_right = dense + array
+    actual = dense.to_dense() + values
+
+    assert isinstance(res_left, DenseLinearOperator)
+    assert isinstance(res_right, DenseLinearOperator)
+    assert approx_equal(res_left.to_dense(), actual)
+    assert approx_equal(res_right.to_dense(), actual)
+
+    # Add Diagonal.
+    diag = DiagonalLinearOperator(diag=entries)
+
+    res_left = dense + diag
+    res_right = diag + dense
+    actual = diag.to_dense() + values
+
+    assert isinstance(res_left, DenseLinearOperator)
+    assert isinstance(res_right, DenseLinearOperator)
+    assert approx_equal(res_left.to_dense(), actual)
+    assert approx_equal(res_right.to_dense(), actual)
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_mul(n: int) -> None:
+    key, subkey = jr.split(_PRNGKey, 2)
+    constant = jr.uniform(key, shape=())
+    values = jr.uniform(subkey, shape=(n, n))
+    dense = DenseLinearOperator(values)
+
+    res_left = dense * constant
+    res_right = constant * dense
+
+    assert isinstance(res_left, DenseLinearOperator)
+    assert isinstance(res_right, DenseLinearOperator)
+    assert approx_equal(res_left.to_dense(), values * constant)
+    assert approx_equal(res_right.to_dense(), values * constant)
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+@pytest.mark.parametrize("m", [1, 2, 5])
+def test_matmul(n: int, m: int) -> None:
+    array_left = jr.uniform(_PRNGKey, shape=(n, m))
+    array_right = jr.uniform(_PRNGKey, shape=(m, n))
+    values = jr.uniform(_PRNGKey, shape=(n, n))
+    dense = DenseLinearOperator(values)
+
+    res_left = dense @ array_left
+    res_right = array_right @ dense
+
+    assert approx_equal(res_left, values @ array_left)
+    assert approx_equal(res_right, array_right @ values)
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_solve(n: int) -> None:
+    sqrt = jr.uniform(_PRNGKey, shape=(n, n))
+    values = sqrt @ sqrt.T
+    dense = DenseLinearOperator(values)
+
+    assert approx_equal(dense.solve(values), jnp.eye(n))
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_inverse(n: int) -> None:
+    sqrt = jr.uniform(_PRNGKey, shape=(n, n))
+    values = sqrt @ sqrt.T
+    dense = DenseLinearOperator(values)
+    res = dense.inverse()
+
+    assert isinstance(res, DenseLinearOperator)
+    assert approx_equal(res.to_dense(), jnp.linalg.inv(values))
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_to_root(n: int) -> None:
+    sqrt = jr.uniform(_PRNGKey, shape=(n, n))
+    values = sqrt @ sqrt.T
+    dense = DenseLinearOperator(values)
+    res = dense.to_root()
+    actual = jnp.linalg.cholesky(values)
+
+    assert isinstance(res, LowerTriangularLinearOperator)
+    assert approx_equal(res.to_dense(), actual)
+    assert res.shape == actual.shape
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_log_det(n: int) -> None:
+    sqrt = jr.uniform(_PRNGKey, shape=(n, n))
+    values = sqrt @ sqrt.T
+    dense = DenseLinearOperator(values)
+    res = dense.log_det()
+    actual = jnp.linalg.slogdet(values)[1]
+
+    approx_equal(res, actual)
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_trace(n: int) -> None:
+    values = jr.uniform(_PRNGKey, shape=(n, n))
+    dense = DenseLinearOperator(values)
+    res = dense.trace()
+    actual = jnp.diag(values).sum()
+
+    assert res == actual
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_from_root(n: int) -> None:
+    sqrt = jr.uniform(_PRNGKey, shape=(n, n))
+    values = sqrt @ sqrt.T
+    L = jnp.linalg.cholesky(values)
+    root = LowerTriangularLinearOperator.from_dense(L)
+    dense = DenseLinearOperator.from_root(root)
+
+    assert isinstance(dense, DenseLinearOperator)
+    assert approx_equal(dense.to_root().to_dense(), root.to_dense())
+    assert approx_equal(dense.to_dense(), values)
+    assert root.shape == dense.shape
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_from_dense(n: int) -> None:
+    values = jr.uniform(_PRNGKey, shape=(n, n))
+    res = DenseLinearOperator.from_dense(values)
+    actual = DenseLinearOperator(values)
+
+    assert isinstance(res, DenseLinearOperator)
+    assert approx_equal(res.to_dense(), actual.to_dense())
+    assert res.shape == actual.shape

--- a/tests/test_dense_linear_operator.py
+++ b/tests/test_dense_linear_operator.py
@@ -144,7 +144,9 @@ def test_mul(n: int) -> None:
 def test_matmul(n: int, m: int) -> None:
     array_left = jr.uniform(_PRNGKey, shape=(n, m))
     array_right = jr.uniform(_PRNGKey, shape=(m, n))
+
     values = jr.uniform(_PRNGKey, shape=(n, n))
+    values = values @ values.T
     dense = DenseLinearOperator(values)
 
     res_left = dense @ array_left

--- a/tests/test_diagonal_linear_operator.py
+++ b/tests/test_diagonal_linear_operator.py
@@ -1,0 +1,240 @@
+# Copyright 2022 The JaxLinOp Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+from jax.config import config
+
+
+# Enable Float64 for more stable matrix inversions.
+config.update("jax_enable_x64", True)
+_PRNGKey = jr.PRNGKey(42)
+
+from jaxlinop.diagonal_linear_operator import DiagonalLinearOperator
+from jaxlinop.dense_linear_operator import DenseLinearOperator
+
+
+def approx_equal(res: jnp.ndarray, actual: jnp.ndarray) -> bool:
+    """Check if two arrays are approximately equal."""
+    return jnp.linalg.norm(res - actual) < 1e-6
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_init(n: int) -> None:
+    values = jr.uniform(_PRNGKey, (n,))
+    diag = DiagonalLinearOperator(values)
+    assert diag.shape == (n, n)
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_diag(n: int) -> None:
+    entries = jr.uniform(_PRNGKey, (n,))
+    diag = DiagonalLinearOperator(entries)
+    res = diag.diagonal()
+    actual = entries
+    assert approx_equal(res, actual)
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_to_dense(n: int) -> None:
+    values = jr.uniform(_PRNGKey, (n,))
+    diag = DiagonalLinearOperator(values)
+    actual = jnp.diag(values)
+    res = diag.to_dense()
+    assert approx_equal(res, actual)
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_add_diagonal(n: int) -> None:
+
+    # Test adding two diagonal linear operators.
+    key_a, key_b = jr.split(_PRNGKey)
+
+    values_a = jr.uniform(key_a, (n,))
+    diag_a = DiagonalLinearOperator(values_a)
+
+    values_b = jr.uniform(key_b, (n,))
+    diag_b = DiagonalLinearOperator(values_b)
+
+    res = diag_a._add_diagonal(diag_b)
+    actual = jnp.diag(values_a + values_b)
+
+    assert isinstance(res, DiagonalLinearOperator)
+    assert res.shape == (n, n)
+    assert approx_equal(res.to_dense(), actual)
+
+    # Test adding on the generic diagonal linear operator.
+    key = _PRNGKey
+
+    values = jr.uniform(key, (n,))
+    diag = DiagonalLinearOperator(values)
+    actual = jnp.diag(values)
+
+    random_diag = DiagonalLinearOperator(jr.uniform(key, (n,)))
+
+    res = diag._add_diagonal(random_diag)
+    actual = jnp.diag(values + random_diag.diagonal())
+
+    assert isinstance(res, DiagonalLinearOperator)
+    assert res.shape == (n, n)
+
+    assert approx_equal(res.to_dense(), actual)
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_add(n: int) -> None:
+    key = _PRNGKey
+
+    array = jr.uniform(_PRNGKey, shape=(n, n))
+    entries = jr.uniform(_PRNGKey, shape=(n,))
+    values = jr.uniform(key, (n,))
+    diag = DiagonalLinearOperator(values)
+
+    # Add array.
+    res_left = diag + array
+    res_right = array + diag
+
+    assert approx_equal(res_left.to_dense(), array + jnp.diag(values))
+    assert approx_equal(res_right.to_dense(), array + jnp.diag(values))
+
+    # Add Dense.
+    array = jr.uniform(_PRNGKey, shape=(n, n))
+    dense = DenseLinearOperator(matrix=array)
+
+    res_left = diag + dense
+    res_right = dense + diag
+    actual = dense.to_dense() + jnp.diag(values)
+
+    assert isinstance(res_left, DenseLinearOperator)
+    assert isinstance(res_right, DenseLinearOperator)
+    assert approx_equal(res_left.to_dense(), actual)
+    assert approx_equal(res_right.to_dense(), actual)
+
+    # Add Diagonal.
+    diag = DiagonalLinearOperator(diag=entries)
+
+    res_left = diag + diag
+    res_right = diag + diag
+    actual = diag.to_dense() + jnp.diag(values)
+
+    assert isinstance(res_left, DiagonalLinearOperator)
+    assert isinstance(res_right, DiagonalLinearOperator)
+    assert approx_equal(res_left.to_dense(), actual)
+    assert approx_equal(res_right.to_dense(), actual)
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_mul(n: int) -> None:
+    key, subkey = jr.split(_PRNGKey, 2)
+    constant = jr.uniform(key, shape=())
+    values = jr.uniform(subkey, shape=(n,))
+    diag = DiagonalLinearOperator(values)
+
+    res_left = diag * constant
+    res_right = constant * diag
+
+    assert isinstance(res_left, DiagonalLinearOperator)
+    assert isinstance(res_right, DiagonalLinearOperator)
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_matmul(n: int) -> None:
+    array = jr.uniform(_PRNGKey, shape=(n, n))
+    values = jr.uniform(_PRNGKey, shape=(n,))
+    diag = DiagonalLinearOperator(values)
+
+    res_left = diag @ array
+    res_right = array @ diag
+
+    assert approx_equal(res_left, diag.to_dense() @ array)
+    assert approx_equal(res_right, array @ diag.to_dense())
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_solve(n: int) -> None:
+    values = jr.uniform(_PRNGKey, shape=(n,))
+    diag = DiagonalLinearOperator(values)
+    rhs = jr.uniform(_PRNGKey, shape=(n,))
+    diag.solve(rhs)
+
+    assert approx_equal(diag.solve(rhs), rhs / values)
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_inverse(n: int) -> None:
+    values = jr.uniform(_PRNGKey, shape=(n,))
+    diag = DiagonalLinearOperator(values)
+    res = diag.inverse()
+
+    assert isinstance(res, DiagonalLinearOperator)
+    assert approx_equal(res.to_dense(), jnp.diag(1 / diag.diagonal()))
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_to_root(n: int) -> None:
+    values = jr.uniform(_PRNGKey, shape=(n,))
+    diag = DiagonalLinearOperator(values)
+    res = diag.to_root()
+    actual = DiagonalLinearOperator(jnp.sqrt(values))
+
+    assert isinstance(res, DiagonalLinearOperator)
+    assert approx_equal(res.to_dense(), actual.to_dense())
+    assert res.shape == actual.shape
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_log_det(n: int) -> None:
+    values = jr.uniform(_PRNGKey, shape=(n,))
+    diag = DiagonalLinearOperator(values)
+    res = diag.log_det()
+    actual = jnp.log(values).sum()
+
+    approx_equal(res, actual)
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_trace(n: int) -> None:
+    values = jr.uniform(_PRNGKey, shape=(n,))
+    diag = DiagonalLinearOperator(values)
+    res = diag.trace()
+    actual = values.sum()
+
+    assert res == actual
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_from_root(n: int) -> None:
+    values = jr.uniform(_PRNGKey, shape=(n,))
+    root = DiagonalLinearOperator(values)
+    diag = DiagonalLinearOperator.from_root(root)
+    res = diag.to_dense()
+    actual = jnp.diag(root.diagonal() ** 2)
+
+    assert isinstance(diag, DiagonalLinearOperator)
+    assert approx_equal(res, actual)
+    assert res.shape == actual.shape
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_from_dense(n: int) -> None:
+    dense = jr.uniform(_PRNGKey, shape=(n, n))
+    res = DiagonalLinearOperator.from_dense(dense)
+    actual = jnp.diag(dense.diagonal())
+
+    assert isinstance(res, DiagonalLinearOperator)
+    assert approx_equal(res.to_dense(), actual)
+    assert res.shape == actual.shape

--- a/tests/test_identity_linear_operator.py
+++ b/tests/test_identity_linear_operator.py
@@ -1,0 +1,180 @@
+# Copyright 2022 The JaxLinOp Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+from jax.config import config
+
+# Enable Float64 for more stable matrix inversions.
+config.update("jax_enable_x64", True)
+_PRNGKey = jr.PRNGKey(42)
+
+from jaxlinop.diagonal_linear_operator import DiagonalLinearOperator
+from jaxlinop.identity_linear_operator import IdentityLinearOperator
+from jaxlinop.constant_diagonal_linear_operator import ConstantDiagonalLinearOperator
+from jaxlinop.dense_linear_operator import DenseLinearOperator
+
+
+def approx_equal(res: jnp.ndarray, actual: jnp.ndarray) -> bool:
+    """Check if two arrays are approximately equal."""
+    return jnp.linalg.norm(res - actual) < 1e-6
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_init(n: int) -> None:
+    id = IdentityLinearOperator(size=n)
+    assert id.shape == (n, n)
+    assert id.size == n
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_diag(n: int) -> None:
+    id = IdentityLinearOperator(size=n)
+    res = id.diagonal()
+    actual = jnp.ones(n)
+    assert approx_equal(res, actual)
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_to_dense(n: int) -> None:
+    id = IdentityLinearOperator(size=n)
+    actual = jnp.eye(n)
+    res = id.to_dense()
+    assert approx_equal(res, actual)
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_add_diagonal(n: int) -> None:
+    id = IdentityLinearOperator(size=n)
+    entries = jr.uniform(_PRNGKey, shape=(n,))
+    diag = DiagonalLinearOperator(diag=entries)
+    id_add_diag = id._add_diagonal(diag)
+
+    assert isinstance(id_add_diag, DiagonalLinearOperator)
+
+    res = id_add_diag.to_dense()
+    actual = jnp.eye(n) * (1.0 + entries)
+    assert approx_equal(res, actual)
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_add(n: int) -> None:
+
+    array = jr.uniform(_PRNGKey, shape=(n, n))
+    entries = jr.uniform(_PRNGKey, shape=(n,))
+    id = IdentityLinearOperator(size=n)
+
+    # Add array.
+    res_left = id + array
+    res_right = array + id
+
+    actual = array + jnp.eye(n)
+
+    assert isinstance(res_left, DenseLinearOperator)
+    assert isinstance(res_right, DenseLinearOperator)
+    assert approx_equal(res_left.to_dense(), actual)
+    assert approx_equal(res_right.to_dense(), actual)
+
+    # Add Dense.
+    dense_lo = DenseLinearOperator(matrix=array)
+
+    res_left = id + dense_lo
+    res_right = dense_lo + id
+    actual = DenseLinearOperator(matrix=array + jnp.eye(n))
+
+    assert isinstance(res_left, DenseLinearOperator)
+    assert isinstance(res_right, DenseLinearOperator)
+    assert approx_equal(res_left.to_dense(), actual.to_dense())
+    assert approx_equal(res_right.to_dense(), actual.to_dense())
+
+    # Add Diagonal.
+    diag = DiagonalLinearOperator(diag=entries)
+
+    res_left = id + diag
+    res_right = diag + id
+    actual = DiagonalLinearOperator(diag=entries + jnp.ones(n))
+
+    assert isinstance(res_left, DiagonalLinearOperator)
+    assert isinstance(res_right, DiagonalLinearOperator)
+    assert approx_equal(res_left.to_dense(), actual.to_dense())
+    assert approx_equal(res_right.to_dense(), actual.to_dense())
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_mul(n: int) -> None:
+    constant = jr.uniform(_PRNGKey, shape=())
+    id = IdentityLinearOperator(size=n)
+
+    res_left = id * constant
+    res_right = constant * id
+
+    assert isinstance(res_left, ConstantDiagonalLinearOperator)
+    assert isinstance(res_right, ConstantDiagonalLinearOperator)
+    assert approx_equal(res_left.to_dense(), constant * jnp.eye(n))
+    assert approx_equal(res_right.to_dense(), constant * jnp.eye(n))
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_matmul(n: int) -> None:
+    array = jr.uniform(_PRNGKey, shape=(n, n))
+    id = IdentityLinearOperator(size=n)
+    res_left = id @ array
+    res_right = array @ id
+    assert isinstance(res_left, jnp.ndarray)
+    assert isinstance(res_right, jnp.ndarray)
+    assert approx_equal(res_left, array)
+    assert approx_equal(res_right, array)
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+@pytest.mark.parametrize("m", [1, 2, 5])
+def test_solve(n: int, m: int) -> None:
+    id = IdentityLinearOperator(size=n)
+    rhs = jr.uniform(_PRNGKey, shape=(n, m))
+    res = id.solve(rhs)
+
+    assert isinstance(res, jnp.ndarray)
+    assert approx_equal(res, rhs)
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_to_root(n: int) -> None:
+    id = IdentityLinearOperator(size=n)
+    res = id.to_root()
+    assert isinstance(res, IdentityLinearOperator)
+    assert approx_equal(res.to_dense(), jnp.eye(n))
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_from_root(n: int) -> None:
+    id = IdentityLinearOperator(size=n)
+    res = IdentityLinearOperator.from_root(id)
+    assert isinstance(res, IdentityLinearOperator)
+    assert approx_equal(res.to_dense(), jnp.eye(n))
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_from_dense(n: int) -> None:
+    dense = jr.uniform(_PRNGKey, shape=(n, n))
+    res = IdentityLinearOperator.from_dense(dense)
+    assert isinstance(res, IdentityLinearOperator)
+    assert approx_equal(res.to_dense(), jnp.eye(n))
+
+
+__all__ = [
+    "IdentityLinearOperator",
+]

--- a/tests/test_linear_operator.py
+++ b/tests/test_linear_operator.py
@@ -13,11 +13,44 @@
 # limitations under the License.
 # ==============================================================================
 
+import pytest
 from jaxlinop.linear_operator import LinearOperator
 
-def test_name() -> None:
-    operator = LinearOperator()
-    res = operator.name
-    actual = "LinearOperator"
-    assert res == actual
 
+def test_covariance_operator() -> None:
+    with pytest.raises(TypeError):
+        LinearOperator()
+
+
+class DummyLinearOperator(LinearOperator):
+    def diagonal(self, *args, **kwargs):
+        pass
+
+    def shape(self, *args, **kwargs):
+        pass
+
+    def __mul__(self, *args, **kwargs):
+        """Multiply linear operator by scalar."""
+        pass
+
+    def _add_diagonal(self, *args, **kwargs):
+        pass
+
+    def __matmul__(self, *args, **kwargs):
+        """Matrix multiplication."""
+        pass
+
+    def to_dense(self, *args, **kwargs):
+        pass
+
+    @classmethod
+    def from_dense(self, *args, **kwargs):
+        pass
+
+
+def test_can_instantiate() -> None:
+    """Test if the covariance operator can be instantiated."""
+    res = DummyLinearOperator()
+
+    assert isinstance(res, DummyLinearOperator)
+    assert res.name == "DummyLinearOperator"

--- a/tests/test_pytree.py
+++ b/tests/test_pytree.py
@@ -1,0 +1,123 @@
+# Copyright 2022 The JaxLinOp Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Adapted from Distrax._src.utils.test_jittable."""
+
+import pytest
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from typing import Any
+from jaxlinop import pytree
+
+
+class DummyJittable(pytree.Pytree):
+    def __init__(self, params):
+        self.name = "dummy"  # Non-JAX property, cannot be traced.
+        self.data = {"params": params}  # Tree property, must be traced recursively.
+
+
+def test_jittable():
+    @jax.jit
+    def get_params(obj):
+        return obj.data["params"]
+
+    obj = DummyJittable(jnp.ones((5,)))
+    np.testing.assert_array_equal(get_params(obj), obj.data["params"])
+
+
+def test_vmappable():
+    def do_sum(obj):
+        return obj.data["params"].sum()
+
+    obj = DummyJittable(jnp.array([[1, 2, 3], [4, 5, 6]]))
+
+    np.testing.assert_array_equal(do_sum(obj), obj.data["params"].sum())
+
+    np.testing.assert_array_equal(
+        jax.vmap(do_sum, in_axes=0)(obj), obj.data["params"].sum(axis=1)
+    )
+
+    np.testing.assert_array_equal(
+        jax.vmap(do_sum, in_axes=1)(obj), obj.data["params"].sum(axis=0)
+    )
+
+
+def test_traceable():
+    @jax.jit
+    def inner_fn(obj):
+        obj.data["params"] *= 3  # Modification after passing to jitted fn.
+        return obj.data["params"].sum()
+
+    def loss_fn(params):
+        obj = DummyJittable(params)
+        obj.data["params"] *= 2  # Modification before passing to jitted fn.
+        return inner_fn(obj)
+
+    params = np.ones((5,))
+    # Both modifications will be traced if data tree is correctly traversed.
+    grad_expected = params * 2 * 3
+    grad = jax.grad(loss_fn)(params)
+    np.testing.assert_array_equal(grad, grad_expected)
+
+    params = jnp.ones((5,))
+    # Both modifications will be traced if data tree is correctly traversed.
+    grad_expected = params * 2 * 3
+    grad = jax.grad(loss_fn)(params)
+    np.testing.assert_array_equal(grad, grad_expected)
+
+
+def test_different_jittables_to_compiled_function():
+    @jax.jit
+    def add_one_to_params(obj):
+        obj.data["params"] = obj.data["params"] + 1
+        return obj
+
+    add_one_to_params(DummyJittable(np.zeros((5,))))
+    add_one_to_params(DummyJittable(np.ones((5,))))
+
+    add_one_to_params(DummyJittable(jnp.zeros((5,))))
+    add_one_to_params(DummyJittable(jnp.ones((5,))))
+
+
+def test_modifying_object_data_does_not_leak_tracers():
+    @jax.jit
+    def add_one_to_params(obj):
+        obj.data["params"] = obj.data["params"] + 1
+        return obj
+
+    dummy = DummyJittable(jnp.ones((5,)))
+    dummy_out = add_one_to_params(dummy)
+    dummy_out.data["params"] -= 1
+
+
+def test_metadata_modification_statements_are_removed_by_compilation():
+    @jax.jit
+    def add_char_to_name(obj):
+        obj.name += "_x"
+        return obj
+
+    dummy = DummyJittable(jnp.ones((5,)))
+    dummy_out = add_char_to_name(dummy)
+    dummy_out = add_char_to_name(dummy)  # `name` change has been compiled out.
+    dummy_out.name += "y"
+    assert dummy_out.name == "dummy_xy"
+
+
+@pytest.mark.parametrize("x", [1, 1.0, True, None])
+def test_is_jax_type(x: Any) -> None:
+    assert pytree.is_jax_type(x) == False

--- a/tests/test_triangular_linear_operator.py
+++ b/tests/test_triangular_linear_operator.py
@@ -1,0 +1,33 @@
+# Copyright 2022 The JaxLinOp Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+from jax.config import config
+from jax.random import KeyArray
+
+# Test settings:
+key: KeyArray = jr.PRNGKey(seed=42)
+jitter: float = 1e-6
+atol: float = 1e-6
+config.update("jax_enable_x64", True)
+
+from jaxlinop.triangular_linear_operator import (
+    LowerTriangularLinearOperator,
+    UpperTriangularLinearOperator,
+)
+from jaxlinop.dense_linear_operator import DenseLinearOperator
+from jaxlinop.diagonal_linear_operator import DiagonalLinearOperator

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,46 @@
+# Copyright 2022 The JaxLinOp Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+from jax.config import config
+
+# Enable Float64 for more stable matrix inversions.
+config.update("jax_enable_x64", True)
+_PRNGKey = jr.PRNGKey(42)
+
+from jaxlinop.identity_linear_operator import IdentityLinearOperator
+from jaxlinop.dense_linear_operator import DenseLinearOperator
+
+from jaxlinop.utils import identity, to_dense
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_identity(n: int) -> None:
+    id = identity(n)
+    assert isinstance(id, IdentityLinearOperator)
+    assert id.shape == (n, n)
+    assert id.size == n
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_to_dense(n: int) -> None:
+    mat = jr.uniform(_PRNGKey, (n, n))
+    lo = DenseLinearOperator(mat)
+
+    assert jnp.allclose(to_dense(lo), lo.to_dense())
+    assert jnp.allclose(to_dense(mat), mat)

--- a/tests/test_zero_linear_operator.py
+++ b/tests/test_zero_linear_operator.py
@@ -1,0 +1,204 @@
+# Copyright 2022 The JaxLinOp Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+from jax.config import config
+
+
+# Enable Float64 for more stable matrix inversions.
+config.update("jax_enable_x64", True)
+_PRNGKey = jr.PRNGKey(42)
+
+from jaxlinop.diagonal_linear_operator import DiagonalLinearOperator
+from jaxlinop.dense_linear_operator import DenseLinearOperator
+from jaxlinop.zero_linear_operator import ZeroLinearOperator
+
+
+def approx_equal(res: jnp.ndarray, actual: jnp.ndarray) -> bool:
+    """Check if two arrays are approximately equal."""
+    return jnp.linalg.norm(res - actual) < 1e-6
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_init(n: int) -> None:
+    zero = ZeroLinearOperator(size=n)
+    assert zero.shape == (n, n)
+    assert zero.size == n
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_diag(n: int) -> None:
+    zero = ZeroLinearOperator(size=n)
+    res = zero.diagonal()
+    actual = jnp.zeros(n)
+    assert approx_equal(res, actual)
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_to_dense(n: int) -> None:
+    zero = ZeroLinearOperator(size=n)
+    actual = jnp.zeros(shape=(n, n))
+    res = zero.to_dense()
+    assert approx_equal(res, actual)
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_add_diagonal(n: int) -> None:
+    zero = ZeroLinearOperator(size=n)
+    entries = jr.uniform(_PRNGKey, shape=(n,))
+    diag = DiagonalLinearOperator(diag=entries)
+    zero_add_diag = zero._add_diagonal(diag)
+
+    assert isinstance(zero_add_diag, DiagonalLinearOperator)
+
+    res = zero_add_diag.to_dense()
+    actual = jnp.eye(n) * entries
+    assert approx_equal(res, actual)
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_add(n: int) -> None:
+
+    array = jr.uniform(_PRNGKey, shape=(n, n))
+    entries = jr.uniform(_PRNGKey, shape=(n,))
+    zero = ZeroLinearOperator(size=n)
+
+    # Add array.
+    res_left = zero + array
+    res_right = array + zero
+
+    assert isinstance(res_left, DenseLinearOperator)
+    assert isinstance(res_right, DenseLinearOperator)
+
+    # Add Dense.
+    dense_lo = DenseLinearOperator(matrix=array)
+
+    res_left = zero + dense_lo
+    res_right = dense_lo + zero
+    actual = dense_lo
+
+    assert isinstance(res_left, DenseLinearOperator)
+    assert isinstance(res_right, DenseLinearOperator)
+    assert approx_equal(res_left.to_dense(), actual.to_dense())
+    assert approx_equal(res_right.to_dense(), actual.to_dense())
+
+    # Add Diagonal.
+    diag = DiagonalLinearOperator(diag=entries)
+
+    res_left = zero + diag
+    res_right = diag + zero
+    actual = diag
+
+    assert isinstance(res_left, DiagonalLinearOperator)
+    assert isinstance(res_right, DiagonalLinearOperator)
+    assert approx_equal(res_left.to_dense(), actual.to_dense())
+    assert approx_equal(res_right.to_dense(), actual.to_dense())
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_mul(n: int) -> None:
+    constant = jr.uniform(_PRNGKey, shape=())
+    zero = ZeroLinearOperator(size=n)
+
+    res_left = zero * constant
+    res_right = constant * zero
+
+    assert isinstance(res_left, ZeroLinearOperator)
+    assert isinstance(res_right, ZeroLinearOperator)
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_matmul(n: int) -> None:
+    array = jr.uniform(_PRNGKey, shape=(n, n))
+    zero = ZeroLinearOperator(size=n)
+
+    res_left = zero @ array
+    res_right = array @ zero
+
+    assert isinstance(res_left, ZeroLinearOperator)
+    assert isinstance(res_right, ZeroLinearOperator)
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_solve(n: int) -> None:
+    zero = ZeroLinearOperator(size=n)
+
+    with pytest.raises(RuntimeError):
+        rhs = jr.uniform(_PRNGKey, shape=(n,))
+        zero.solve(rhs)
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_inverse(n: int) -> None:
+    zero = ZeroLinearOperator(size=n)
+
+    with pytest.raises(RuntimeError):
+        zero.inverse()
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_to_root(n: int) -> None:
+    zero = ZeroLinearOperator(size=n)
+
+    res = zero.to_root()
+    actual = zero
+
+    assert isinstance(res, ZeroLinearOperator)
+    assert approx_equal(res.to_dense(), actual.to_dense())
+    assert res.shape == actual.shape
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_log_det(n: int) -> None:
+    zero = ZeroLinearOperator(size=n)
+
+    assert zero.log_det() == jnp.log(0.0)
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_trace(n: int) -> None:
+    zero = ZeroLinearOperator(size=n)
+    res = zero.trace()
+    actual = 0.0
+
+    assert res == actual
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_from_root(n: int) -> None:
+    zero = ZeroLinearOperator(size=n)
+
+    res = ZeroLinearOperator.from_root(zero)
+    actual = zero
+
+    assert isinstance(res, ZeroLinearOperator)
+    assert approx_equal(res.to_dense(), actual.to_dense())
+    assert res.shape == actual.shape
+
+
+@pytest.mark.parametrize("n", [1, 2, 5])
+def test_from_dense(n: int) -> None:
+    zero = ZeroLinearOperator(size=n)
+
+    dense = jr.uniform(_PRNGKey, shape=(n, n))
+    res = ZeroLinearOperator.from_dense(dense)
+    actual = zero
+
+    assert isinstance(res, ZeroLinearOperator)
+    assert approx_equal(res.to_dense(), actual.to_dense())
+    assert res.shape == actual.shape


### PR DESCRIPTION
# v0.0.1

## Added:
- `LinearOperator` base class.
- `DenseLinearOperator`.
- `DiagonalLinearOperator`.
- `ConstantDiagonalLinearOperator`.
- `LowerTriangularLinearOperator`.
- `UpperTriangularLinearOperator`.
- `ZeroLinearOperator`.
- `IdentityLinearOperator`.

And a minimal set of tests.


## Issues to open:

- All operators are assumed to be positive definite, except for the lower and upper triangular linear operators. In future, we will abstract this property out, and allow for non-square matrices.
- We have that addition between the operators returns an operator, but matrix multiplication on the other hand is only defined between an operator and a `jnp.ndarray`. This inconsistent type promotion needs addressing in a future release.
- Would like to see cacheing of linear operator computations, particularly the `LinearOperator.to_root` operation.
- Would like to see overloading of `jnp` operations e.g., `jnp.sum` that work with the linear operators. But have this disabled by default, and activated by a global config.
- Would like to see the linear operators blend with `distrax.Bijector`. Currently plan to implement this via `LinearOperator.to_bijector`.
- Examples of how to use the library.

